### PR TITLE
Create ASP.NET Core Azure Search + OpenAI demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+*.user
+*.suo
+*.userprefs
+*.db
+*.DS_Store
+.vs/
+launchSettings.json
+appsettings.Development.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,128 @@
-# OpenAI-Codex-Demo
+# Azure Cognitive Search + Azure OpenAI Demo (.NET)
+
+This repository contains a C#/.NET implementation of the experience provided in the original [azure-search-openai-demo](https://github.com/Azure-Samples/azure-search-openai-demo). It exposes a Web API that orchestrates Azure Cognitive Search and Azure OpenAI to answer questions with cited references.
+
+## Features
+
+- **Retrieval augmented generation** powered by Azure Cognitive Search (semantic + vector search) and Azure OpenAI chat completions.
+- **Citation tracking** – responses include identifiers that map back to the retrieved documents.
+- **Configurable prompts** and conversation history so that the assistant can maintain context across turns.
+- **REST endpoints** for both chat completions and raw search results so the API can be consumed from any client (web, desktop, mobile, bots, etc.).
+
+## Project structure
+
+```
+src/
+  AzureSearchOpenAIDemo.sln           # Solution file
+  AzureSearchOpenAIDemo.Api/          # ASP.NET Core Web API project
+    Controllers/                      # REST endpoints for chat and search
+    Models/                           # DTOs used by the API
+    Options/                          # Configuration bindings
+    Orchestration/                    # Chat orchestration logic
+    Services/                         # Azure Cognitive Search and Azure OpenAI integrations
+```
+
+## Prerequisites
+
+- .NET 8 SDK or later
+- An [Azure Cognitive Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search) service with an index containing the documents you want to ground answers on
+- An [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) resource with:
+  - A chat completion deployment (for example, `gpt-35-turbo` or `gpt-4o-mini`)
+  - An embeddings deployment (for example, `text-embedding-ada-002` or `text-embedding-3-large`)
+
+## Configuration
+
+Copy `src/AzureSearchOpenAIDemo.Api/appsettings.json` and provide the settings for your environment (you can use `appsettings.Development.json` locally). The main configuration sections are:
+
+- `AzureOpenAI`
+  - `Endpoint`: Base URL of your Azure OpenAI resource
+  - `ApiKey`: API key for the resource
+  - `DeploymentName`: Name of the chat completion deployment
+  - `EmbeddingDeploymentName`: Name of the embedding deployment (needed for vector search)
+  - `Temperature`, `TopP`, `MaxTokens`: Generation controls
+- `AzureSearch`
+  - `Endpoint`: Base URL of your Cognitive Search service
+  - `IndexName`: Name of the search index that stores your documents
+  - `ApiKey`: Admin or query API key
+  - `SemanticConfiguration`: Semantic configuration defined on your index
+  - `SearchFields`: Fields searched for keyword/semantic queries
+  - `VectorFieldName`: Name of the vector field on the index (optional but recommended)
+  - `DefaultTop`: Default number of results to retrieve
+  - `MinimumSemanticScore`: Filter out low relevance results when using semantic ranking
+
+> **Tip**: The API expects the index to contain fields such as `title`, `content`, and `source` (similar to the official sample). Adjust `AzureSearchOptions` or the mapping logic in `AzureSearchService` if your schema differs.
+
+## Running the API
+
+```bash
+cd src
+# Restore dependencies (optional if you open the solution in Visual Studio/VS Code)
+dotnet restore
+
+# Run the ASP.NET Core Web API
+dotnet run --project AzureSearchOpenAIDemo.Api
+```
+
+By default the API listens on `https://localhost:7240` and `http://localhost:5240`. Swagger UI is enabled in development for quick testing.
+
+## Endpoints
+
+- `POST /api/search` – accepts a `SearchRequest` payload and returns the raw search results used for grounding.
+- `POST /api/chat` – accepts a `ChatRequest` payload and returns a `ChatResponse` containing:
+  - `Answer`: Assistant response text with citations like `[doc1]`
+  - `Citations`: Structured information about the cited documents
+  - `History`: Updated conversation history including the assistant reply
+  - `SourceDocuments`: Raw search results with content, scores, and highlights
+
+### Sample request body (`/api/chat`)
+
+```json
+{
+  "question": "What does the user guide say about warranty coverage?",
+  "top": 5,
+  "history": [],
+  "useSemanticCaptions": true
+}
+```
+
+### Sample response body (`/api/chat`)
+
+```json
+{
+  "answer": "The warranty covers factory defects for one year from the purchase date [doc1].",
+  "citations": [
+    {
+      "id": "doc1",
+      "title": "Contoso Warranty Policy",
+      "source": "https://contoso.com/warranty.pdf"
+    }
+  ],
+  "history": [
+    { "role": "user", "content": "What does the user guide say about warranty coverage?" },
+    { "role": "assistant", "content": "The warranty covers factory defects..." }
+  ],
+  "sourceDocuments": [
+    {
+      "citationId": "doc1",
+      "title": "Contoso Warranty Policy",
+      "content": "..."
+    }
+  ]
+}
+```
+
+## Extending the sample
+
+- **Front-end**: Pair the API with any web or native client. The original sample uses Next.js + React – you can reuse that UI with this backend.
+- **Data ingestion**: Use Azure Cognitive Search indexers, Azure Functions, Logic Apps, or custom code to populate the search index with your content.
+- **Authentication**: The API currently assumes trusted callers. Add Azure AD authentication/authorization for production scenarios.
+
+## Troubleshooting
+
+- Ensure your Azure resources allow requests from your network.
+- Confirm that the search index schema matches the fields referenced in `AzureSearchService`.
+- If you do not have an embeddings deployment, set `UseVector` to `false` in requests or remove the vector configuration.
+
+## License
+
+This project is provided under the [MIT License](LICENSE).

--- a/src/AzureSearchOpenAIDemo.Api/AzureSearchOpenAIDemo.Api.csproj
+++ b/src/AzureSearchOpenAIDemo.Api/AzureSearchOpenAIDemo.Api.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/AzureSearchOpenAIDemo.Api/Controllers/ChatController.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Controllers/ChatController.cs
@@ -1,0 +1,26 @@
+using AzureSearchOpenAIDemo.Api.Models;
+using AzureSearchOpenAIDemo.Api.Orchestration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzureSearchOpenAIDemo.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ChatController : ControllerBase
+{
+    private readonly ChatOrchestrator _orchestrator;
+
+    public ChatController(ChatOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ChatResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> PostAsync([FromBody] ChatRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _orchestrator.GetResponseAsync(request, cancellationToken);
+        return Ok(response);
+    }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Controllers/SearchController.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Controllers/SearchController.cs
@@ -1,0 +1,26 @@
+using AzureSearchOpenAIDemo.Api.Models;
+using AzureSearchOpenAIDemo.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzureSearchOpenAIDemo.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SearchController : ControllerBase
+{
+    private readonly IAzureSearchService _searchService;
+
+    public SearchController(IAzureSearchService searchService)
+    {
+        _searchService = searchService;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(IReadOnlyList<SearchDocumentResult>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> PostAsync([FromBody] SearchRequest request, CancellationToken cancellationToken)
+    {
+        var results = await _searchService.SearchAsync(request, cancellationToken);
+        return Ok(results);
+    }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/ChatMessage.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/ChatMessage.cs
@@ -1,0 +1,8 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class ChatMessage
+{
+    public string Role { get; set; } = "user";
+
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/ChatRequest.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/ChatRequest.cs
@@ -1,0 +1,14 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class ChatRequest
+{
+    public string Question { get; set; } = string.Empty;
+
+    public IList<ChatMessage> History { get; set; } = new List<ChatMessage>();
+
+    public int? Top { get; set; }
+
+    public string? OverridePrompt { get; set; }
+
+    public bool UseSemanticCaptions { get; set; } = true;
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/ChatResponse.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/ChatResponse.cs
@@ -1,0 +1,12 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class ChatResponse
+{
+    public string Answer { get; set; } = string.Empty;
+
+    public IList<Citation> Citations { get; set; } = new List<Citation>();
+
+    public IList<ChatMessage> History { get; set; } = new List<ChatMessage>();
+
+    public IList<SearchDocumentResult> SourceDocuments { get; set; } = new List<SearchDocumentResult>();
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/Citation.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/Citation.cs
@@ -1,0 +1,14 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class Citation
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string? Source { get; set; }
+
+    public string? Url { get; set; }
+
+    public string? Content { get; set; }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/SearchDocumentResult.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/SearchDocumentResult.cs
@@ -1,0 +1,18 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class SearchDocumentResult
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Content { get; set; } = string.Empty;
+
+    public string? Source { get; set; }
+
+    public double Score { get; set; }
+
+    public string CitationId { get; set; } = string.Empty;
+
+    public IDictionary<string, IReadOnlyList<string>> Highlights { get; set; } = new Dictionary<string, IReadOnlyList<string>>();
+}

--- a/src/AzureSearchOpenAIDemo.Api/Models/SearchRequest.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Models/SearchRequest.cs
@@ -1,0 +1,14 @@
+namespace AzureSearchOpenAIDemo.Api.Models;
+
+public class SearchRequest
+{
+    public string Query { get; set; } = string.Empty;
+
+    public int? Top { get; set; }
+
+    public string? Filter { get; set; }
+
+    public bool UseVector { get; set; }
+
+    public bool UseSemantic { get; set; } = true;
+}

--- a/src/AzureSearchOpenAIDemo.Api/Options/AzureOpenAIOptions.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Options/AzureOpenAIOptions.cs
@@ -1,0 +1,24 @@
+namespace AzureSearchOpenAIDemo.Api.Options;
+
+public class AzureOpenAIOptions
+{
+    public const string SectionName = "AzureOpenAI";
+
+    public string? Endpoint { get; set; }
+
+    public string? ApiKey { get; set; }
+
+    public string? DeploymentName { get; set; }
+
+    public string? EmbeddingDeploymentName { get; set; }
+
+    public string? ApiVersion { get; set; }
+
+    public float Temperature { get; set; } = 0.3f;
+
+    public float TopP { get; set; } = 0.95f;
+
+    public int MaxTokens { get; set; } = 1024;
+
+    public bool StreamResponses { get; set; }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Options/AzureSearchOptions.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Options/AzureSearchOptions.cs
@@ -1,0 +1,24 @@
+namespace AzureSearchOpenAIDemo.Api.Options;
+
+public class AzureSearchOptions
+{
+    public const string SectionName = "AzureSearch";
+
+    public string? Endpoint { get; set; }
+
+    public string? IndexName { get; set; }
+
+    public string? ApiKey { get; set; }
+
+    public string? SemanticConfiguration { get; set; }
+
+    public string[]? SearchFields { get; set; }
+
+    public string? VectorFieldName { get; set; }
+
+    public int VectorDimensions { get; set; } = 1536;
+
+    public int DefaultTop { get; set; } = 3;
+
+    public double? MinimumSemanticScore { get; set; }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Orchestration/ChatOrchestrator.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Orchestration/ChatOrchestrator.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using AzureSearchOpenAIDemo.Api.Models;
+using AzureSearchOpenAIDemo.Api.Options;
+using AzureSearchOpenAIDemo.Api.Services;
+using Microsoft.Extensions.Options;
+
+namespace AzureSearchOpenAIDemo.Api.Orchestration;
+
+public class ChatOrchestrator
+{
+    private const string DefaultPrompt = """
+You are an intelligent assistant helping users with information retrieved from Azure Cognitive Search.
+Answer the user's question using only the provided sources. Always cite sources in square brackets using their identifiers (for example, [doc1]).
+If the answer cannot be determined from the sources, say you do not know.
+""";
+
+    private static readonly Regex CitationRegex = new("\\[(doc\\d+)\\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IAzureSearchService _searchService;
+    private readonly IOpenAIService _openAiService;
+    private readonly AzureOpenAIOptions _openAiOptions;
+
+    public ChatOrchestrator(IAzureSearchService searchService, IOpenAIService openAiService, IOptions<AzureOpenAIOptions> openAiOptions)
+    {
+        _searchService = searchService;
+        _openAiService = openAiService;
+        _openAiOptions = openAiOptions.Value;
+    }
+
+    public async Task<ChatResponse> GetResponseAsync(ChatRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Question))
+        {
+            throw new ArgumentException("The question cannot be empty.", nameof(request));
+        }
+
+        var searchResults = await _searchService.SearchAsync(new SearchRequest
+        {
+            Query = request.Question,
+            Top = request.Top,
+            UseSemantic = request.UseSemanticCaptions,
+            UseVector = !string.IsNullOrWhiteSpace(_openAiOptions.EmbeddingDeploymentName)
+        }, cancellationToken);
+
+        string context = BuildContextMessage(searchResults);
+
+        var conversation = new List<ChatMessage>
+        {
+            new()
+            {
+                Role = "system",
+                Content = string.IsNullOrWhiteSpace(request.OverridePrompt) ? DefaultPrompt : request.OverridePrompt!
+            },
+            new()
+            {
+                Role = "system",
+                Content = context
+            }
+        };
+
+        if (request.History.Count > 0)
+        {
+            conversation.AddRange(request.History.Select(m => new ChatMessage
+            {
+                Role = m.Role,
+                Content = m.Content
+            }));
+        }
+
+        conversation.Add(new ChatMessage
+        {
+            Role = "user",
+            Content = request.Question
+        });
+
+        var assistantMessage = await _openAiService.GetChatCompletionAsync(conversation, cancellationToken);
+
+        var updatedHistory = new List<ChatMessage>(request.History)
+        {
+            new() { Role = "user", Content = request.Question },
+            assistantMessage
+        };
+
+        var citations = ExtractCitations(assistantMessage.Content, searchResults);
+
+        return new ChatResponse
+        {
+            Answer = assistantMessage.Content,
+            Citations = citations,
+            History = updatedHistory,
+            SourceDocuments = searchResults.ToList()
+        };
+    }
+
+    private static string BuildContextMessage(IReadOnlyList<SearchDocumentResult> documents)
+    {
+        if (documents.Count == 0)
+        {
+            return "No sources were found for this query.";
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("The following documents are available as reference sources:");
+        builder.AppendLine();
+
+        foreach (var document in documents)
+        {
+            builder.AppendLine($"[{document.CitationId}] {document.Title}");
+            if (!string.IsNullOrWhiteSpace(document.Source))
+            {
+                builder.AppendLine($"Source: {document.Source}");
+            }
+
+            builder.AppendLine(document.Content);
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static IList<Citation> ExtractCitations(string answer, IReadOnlyList<SearchDocumentResult> documents)
+    {
+        var citations = new List<Citation>();
+
+        if (string.IsNullOrWhiteSpace(answer))
+        {
+            return citations;
+        }
+
+        var matches = CitationRegex.Matches(answer);
+        foreach (Match match in matches)
+        {
+            var citationId = match.Groups[1].Value;
+            var document = documents.FirstOrDefault(d => string.Equals(d.CitationId, citationId, StringComparison.OrdinalIgnoreCase));
+
+            if (document is not null && citations.All(c => !string.Equals(c.Id, document.CitationId, StringComparison.OrdinalIgnoreCase)))
+            {
+                citations.Add(new Citation
+                {
+                    Id = document.CitationId,
+                    Title = document.Title,
+                    Source = document.Source,
+                    Content = document.Content
+                });
+            }
+        }
+
+        return citations;
+    }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Program.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Program.cs
@@ -1,0 +1,29 @@
+using AzureSearchOpenAIDemo.Api.Options;
+using AzureSearchOpenAIDemo.Api.Orchestration;
+using AzureSearchOpenAIDemo.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.Configure<AzureOpenAIOptions>(builder.Configuration.GetSection(AzureOpenAIOptions.SectionName));
+builder.Services.Configure<AzureSearchOptions>(builder.Configuration.GetSection(AzureSearchOptions.SectionName));
+
+builder.Services.AddSingleton<IAzureSearchService, AzureSearchService>();
+builder.Services.AddSingleton<IOpenAIService, OpenAIService>();
+builder.Services.AddSingleton<ChatOrchestrator>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.MapControllers();
+
+app.Run();

--- a/src/AzureSearchOpenAIDemo.Api/Services/AzureSearchService.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Services/AzureSearchService.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using System.Text;
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using AzureSearchOpenAIDemo.Api.Models;
+using AzureSearchOpenAIDemo.Api.Options;
+using Microsoft.Extensions.Options;
+
+namespace AzureSearchOpenAIDemo.Api.Services;
+
+public class AzureSearchService : IAzureSearchService
+{
+    private readonly AzureSearchOptions _options;
+    private readonly IOpenAIService _openAiService;
+    private readonly SearchClient _searchClient;
+
+    public AzureSearchService(IOptions<AzureSearchOptions> options, IOpenAIService openAiService)
+    {
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _openAiService = openAiService;
+
+        if (string.IsNullOrWhiteSpace(_options.Endpoint))
+        {
+            throw new InvalidOperationException("Azure Search endpoint is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.IndexName))
+        {
+            throw new InvalidOperationException("Azure Search index name is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+        {
+            throw new InvalidOperationException("Azure Search API key is not configured.");
+        }
+
+        _searchClient = new SearchClient(new Uri(_options.Endpoint), _options.IndexName, new AzureKeyCredential(_options.ApiKey));
+    }
+
+    public async Task<IReadOnlyList<SearchDocumentResult>> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Query))
+        {
+            return Array.Empty<SearchDocumentResult>();
+        }
+
+        int top = request.Top ?? _options.DefaultTop;
+
+        var options = new SearchOptions
+        {
+            Size = top,
+            IncludeTotalCount = true
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.Filter))
+        {
+            options.Filter = request.Filter;
+        }
+
+        if (_options.SearchFields is { Length: > 0 })
+        {
+            foreach (var field in _options.SearchFields)
+            {
+                options.SearchFields.Add(field);
+            }
+        }
+
+        bool useSemanticSearch = request.UseSemantic && !string.IsNullOrWhiteSpace(_options.SemanticConfiguration);
+        if (useSemanticSearch)
+        {
+            options.QueryType = SearchQueryType.Semantic;
+            options.SemanticConfigurationName = _options.SemanticConfiguration;
+            options.QueryLanguage = QueryLanguage.EnUs;
+            options.QueryCaption = QueryCaptionType.Extractive;
+            options.QueryAnswer = QueryAnswerType.Extractive;
+        }
+
+        if (request.UseVector && !string.IsNullOrWhiteSpace(_options.VectorFieldName))
+        {
+            var embedding = await _openAiService.GenerateEmbeddingsAsync(request.Query, cancellationToken);
+            options.VectorSearch = new VectorSearchOptions
+            {
+                Queries =
+                {
+                    new VectorQuery(new ReadOnlyMemory<float>(embedding.ToArray()))
+                    {
+                        KNearestNeighborsCount = top,
+                        Fields = { _options.VectorFieldName }
+                    }
+                }
+            };
+        }
+
+        var response = await _searchClient.SearchAsync<SearchDocument>(request.Query, options, cancellationToken);
+
+        var documents = new List<SearchDocumentResult>();
+        int index = 1;
+
+        await foreach (var result in response.Value.GetResultsAsync())
+        {
+            if (_options.MinimumSemanticScore.HasValue && result.RerankerScore.HasValue && result.RerankerScore.Value < _options.MinimumSemanticScore.Value)
+            {
+                continue;
+            }
+
+            var document = result.Document;
+
+            string? title = TryGetString(document, "title", "metadata_title", "name");
+            string? content = TryGetString(document, "content", "chunks", "text");
+
+            if (useSemanticSearch && result.SemanticCaptions is { Count: > 0 })
+            {
+                content = string.Join(Environment.NewLine, result.SemanticCaptions.Select(c => c.Text));
+            }
+
+            documents.Add(new SearchDocumentResult
+            {
+                Id = TryGetString(document, "id", "metadata_storage_path") ?? index.ToString(),
+                Title = title ?? $"Document {index}",
+                Content = content ?? string.Empty,
+                Source = TryGetString(document, "source", "url", "filepath"),
+                Score = result.Score ?? 0,
+                CitationId = $"doc{index}",
+                Highlights = result.Highlights?.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<string>)kvp.Value.ToList()) ?? new Dictionary<string, IReadOnlyList<string>>()
+            });
+
+            index++;
+        }
+
+        return documents;
+    }
+
+    private static string? TryGetString(SearchDocument document, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (document.TryGetValue(key, out var value) && value is not null)
+            {
+                switch (value)
+                {
+                    case string s:
+                        return s;
+                    case IEnumerable<string> strings:
+                        return string.Join(Environment.NewLine, strings);
+                    case IEnumerable<object> objects:
+                        var builder = new StringBuilder();
+                        foreach (var item in objects)
+                        {
+                            if (item is string str)
+                            {
+                                builder.AppendLine(str);
+                            }
+                        }
+
+                        if (builder.Length > 0)
+                        {
+                            return builder.ToString();
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/AzureSearchOpenAIDemo.Api/Services/IAzureSearchService.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Services/IAzureSearchService.cs
@@ -1,0 +1,8 @@
+using AzureSearchOpenAIDemo.Api.Models;
+
+namespace AzureSearchOpenAIDemo.Api.Services;
+
+public interface IAzureSearchService
+{
+    Task<IReadOnlyList<SearchDocumentResult>> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/AzureSearchOpenAIDemo.Api/Services/IOpenAIService.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Services/IOpenAIService.cs
@@ -1,0 +1,10 @@
+using AzureSearchOpenAIDemo.Api.Models;
+
+namespace AzureSearchOpenAIDemo.Api.Services;
+
+public interface IOpenAIService
+{
+    Task<ChatMessage> GetChatCompletionAsync(IEnumerable<ChatMessage> messages, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<float>> GenerateEmbeddingsAsync(string input, CancellationToken cancellationToken = default);
+}

--- a/src/AzureSearchOpenAIDemo.Api/Services/OpenAIService.cs
+++ b/src/AzureSearchOpenAIDemo.Api/Services/OpenAIService.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using Azure;
+using Azure.AI.OpenAI;
+using AzureSearchOpenAIDemo.Api.Models;
+using AzureSearchOpenAIDemo.Api.Options;
+using Microsoft.Extensions.Options;
+
+namespace AzureSearchOpenAIDemo.Api.Services;
+
+public class OpenAIService : IOpenAIService
+{
+    private readonly AzureOpenAIOptions _options;
+    private readonly OpenAIClient _client;
+
+    public OpenAIService(IOptions<AzureOpenAIOptions> options)
+    {
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+
+        if (string.IsNullOrWhiteSpace(_options.Endpoint))
+        {
+            throw new InvalidOperationException("Azure OpenAI endpoint is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+        {
+            throw new InvalidOperationException("Azure OpenAI API key is not configured.");
+        }
+
+        var credential = new AzureKeyCredential(_options.ApiKey);
+        _client = new OpenAIClient(new Uri(_options.Endpoint), credential);
+    }
+
+    public async Task<ChatMessage> GetChatCompletionAsync(IEnumerable<ChatMessage> messages, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.DeploymentName))
+        {
+            throw new InvalidOperationException("Azure OpenAI chat deployment name is not configured.");
+        }
+
+        var chatOptions = new ChatCompletionsOptions
+        {
+            MaxTokens = _options.MaxTokens,
+            Temperature = _options.Temperature,
+            TopP = _options.TopP
+        };
+
+        foreach (var message in messages)
+        {
+            chatOptions.Messages.Add(new Azure.AI.OpenAI.ChatMessage(ToChatRole(message.Role), message.Content));
+        }
+
+        var response = await _client.GetChatCompletionsAsync(_options.DeploymentName, chatOptions, cancellationToken).ConfigureAwait(false);
+        var choice = response.Value.Choices.FirstOrDefault();
+
+        if (choice?.Message is null)
+        {
+            throw new InvalidOperationException("Azure OpenAI did not return any completions.");
+        }
+
+        string content = choice.Message.Content ?? string.Empty;
+
+        return new ChatMessage
+        {
+            Role = "assistant",
+            Content = content
+        };
+    }
+
+    public async Task<IReadOnlyList<float>> GenerateEmbeddingsAsync(string input, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.EmbeddingDeploymentName))
+        {
+            throw new InvalidOperationException("Azure OpenAI embedding deployment name is not configured.");
+        }
+
+        var embeddingOptions = new EmbeddingsOptions();
+        embeddingOptions.Input.Add(input);
+
+        var response = await _client.GetEmbeddingsAsync(_options.EmbeddingDeploymentName, embeddingOptions, cancellationToken).ConfigureAwait(false);
+        var vector = response.Value.Data.FirstOrDefault()?.Embedding;
+
+        if (vector is null)
+        {
+            throw new InvalidOperationException("Azure OpenAI did not return any embeddings.");
+        }
+
+        return vector.ToArray();
+    }
+
+    private static ChatRole ToChatRole(string? role)
+    {
+        return role?.ToLowerInvariant() switch
+        {
+            "assistant" => ChatRole.Assistant,
+            "system" => ChatRole.System,
+            _ => ChatRole.User
+        };
+    }
+}

--- a/src/AzureSearchOpenAIDemo.Api/appsettings.json
+++ b/src/AzureSearchOpenAIDemo.Api/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "AzureOpenAI": {
+    "Endpoint": "https://YOUR-AOAI-RESOURCE.openai.azure.com/",
+    "ApiKey": "YOUR-AZURE-OPENAI-KEY",
+    "DeploymentName": "gpt-35-turbo",
+    "EmbeddingDeploymentName": "text-embedding-ada-002",
+    "Temperature": 0.3,
+    "TopP": 0.95,
+    "MaxTokens": 1024
+  },
+  "AzureSearch": {
+    "Endpoint": "https://YOUR-SEARCH-RESOURCE.search.windows.net/",
+    "IndexName": "azure-search-openai-demo",
+    "ApiKey": "YOUR-AZURE-SEARCH-KEY",
+    "SemanticConfiguration": "default",
+    "SearchFields": [ "title", "content" ],
+    "VectorFieldName": "contentVector",
+    "VectorDimensions": 1536,
+    "DefaultTop": 3,
+    "MinimumSemanticScore": 0.4
+  },
+  "AllowedHosts": "*"
+}

--- a/src/AzureSearchOpenAIDemo.sln
+++ b/src/AzureSearchOpenAIDemo.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureSearchOpenAIDemo.Api", "AzureSearchOpenAIDemo.Api/AzureSearchOpenAIDemo.Api.csproj", "{BD9A82C6-1B32-4F4D-8D39-4E95A0ECB506}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {BD9A82C6-1B32-4F4D-8D39-4E95A0ECB506}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {BD9A82C6-1B32-4F4D-8D39-4E95A0ECB506}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {BD9A82C6-1B32-4F4D-8D39-4E95A0ECB506}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {BD9A82C6-1B32-4F4D-8D39-4E95A0ECB506}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add an ASP.NET Core Web API that mirrors the Azure Search + OpenAI sample with chat and search endpoints
- implement orchestration, search, and OpenAI services plus supporting models and configuration
- document configuration and usage details for running the .NET version of the demo

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca13917384832fa6f40852dff88445